### PR TITLE
Pass missing BACKEND parameter to grade_lab2_ex2()

### DIFF
--- a/labs/lab2/lab2.ipynb
+++ b/labs/lab2/lab2.ipynb
@@ -148,7 +148,7 @@
    "source": [
     "# grade part 2\n",
     "from qc_grader.challenges.qgss_2024 import grade_lab2_ex2\n",
-    "grade_lab2_ex2(LAYER_1_ANSWER, LAYER_2_ANSWER, PATH_ANSWER)"
+    "grade_lab2_ex2(LAYER_1_ANSWER, LAYER_2_ANSWER, PATH_ANSWER, BACKEND)"
    ]
   },
   {


### PR DESCRIPTION
In part 2 of the lab, the `grade_lab2_ex2()` fails due to a missing `BACKEND` parameter:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[21], [line 3](vscode-notebook-cell:?execution_count=21&line=3)
      [1](vscode-notebook-cell:?execution_count=21&line=1) # grade part [2](vscode-notebook-cell:?execution_count=21&line=2)
      2 from qc_grader.challenges.qgss_2024 import grade_lab2_ex2
----> [3](vscode-notebook-cell:?execution_count=21&line=3) grade_lab2_ex2(LAYER_1_ANSWER, LAYER_2_ANSWER, PATH_ANSWER)

TypeError: grade_lab2_ex2() missing 1 required positional argument: 'backend'
```

This commit modifies the grading cell to pass `BACKEND` as the fourth argument to the `grade_lab2_ex2()` function: