### PR TITLE
Update lab4.ipynb

### DIFF
--- a/labs/lab4/lab4.ipynb
+++ b/labs/lab4/lab4.ipynb
@@ -241,7 +241,7 @@
     "\\end{align}\n",
     "\n",
     "and if we plug in the Hamiltonian of *our* system, the time evolution operator then appears as\n",
-    "$$ U(t) = \\exp\\left(-it\\sum_{i=1}^NX_iX_{i+1} + Y_iY_{i+1} + \\Delta Z_iZ_{i+1} + hX_i\\right) $$.\n",
+    "$$ U(t) = \\exp\\left(-it\\sum_{i=1}^NX_iX_{i+1} + Y_iY_{i+1} + \\Delta Z_iZ_{i+1} + hX_i\\right) $$\n",
     "\n",
     "Next we need to consider how to decompose this into a linear combination of gates which can be executed using a quantum computer. In general, the time evolution operator must be approximated and, conveniently, the Qiskit SDK has some built-in functionality to assist us in generating this. We will use the `PauliEvolutionGate` object and `LieTrotter` synthesis class to use the Li-Trotter approximation for $U(t)$.\n",
     "\n",


### PR DESCRIPTION
Remove the extra period that is causing a markdown rendering error in the lab notebook.